### PR TITLE
Add #include <string>

### DIFF
--- a/emoji.h
+++ b/emoji.h
@@ -1,4 +1,5 @@
 #include <map>
+#include <string>
 
 namespace emojicpp {
 


### PR DESCRIPTION
Add `#include <string>` so that if `emoji.h` is included first, compilation does not fail:
```
emoji.h(5,26): error C2039: 'string': is not a member of 'std'
```